### PR TITLE
Fix cs/stan

### DIFF
--- a/tests/unit/Differ/DiffCollectorTest.php
+++ b/tests/unit/Differ/DiffCollectorTest.php
@@ -135,6 +135,9 @@ final class DiffCollectorTest extends TestCase
         $this->assertCount($expectCount, $actual);
     }
 
+    /**
+     * @return iterable<array{int, bool, GitInterface, DiffFactory}>
+     */
     public static function provideGetPhpDiffsAstChangedCases(): iterable
     {
         $git = new class extends DummyGit {

--- a/tests/unit/Differ/DiffFactoryTest.php
+++ b/tests/unit/Differ/DiffFactoryTest.php
@@ -56,6 +56,9 @@ final class DiffFactoryTest extends TestCase
         $this->assertSame($expectedHead, $actual->head);
     }
 
+    /**
+     * @return iterable<array{GitStatus, ?string, ?string}>
+     */
     public static function provideCreateForPhpCases(): iterable
     {
         yield 'ADDED' => [GitStatus::ADDED, null, '<?php $hash = \'commit2\'; $path = \'a.php\';'];


### PR DESCRIPTION
This pull request updates several test methods to improve clarity and consistency in naming conventions for data providers and their return types. The changes primarily involve renaming data provider methods and adding type annotations to enhance readability and maintainability.

### Updates to data providers:

* [`tests/unit/Differ/DiffCollectorTest.php`](diffhunk://#diff-b1be9b56e54ed083fb3de0cb804f9f98ab0aeb2e0f938f5abce2c53577b70502L127-R127): Renamed the data provider method `getPhpDiffsAstChangedProvider` to `provideGetPhpDiffsAstChangedCases` and added a type annotation specifying the return type as `iterable<array{int, bool, GitInterface, DiffFactory}>`. [[1]](diffhunk://#diff-b1be9b56e54ed083fb3de0cb804f9f98ab0aeb2e0f938f5abce2c53577b70502L127-R127) [[2]](diffhunk://#diff-b1be9b56e54ed083fb3de0cb804f9f98ab0aeb2e0f938f5abce2c53577b70502L138-R141)
* [`tests/unit/Differ/DiffFactoryTest.php`](diffhunk://#diff-2c037140500df0aea328f2e7461eb2a08a55ffdeec0fa33c0a8fe9e31fb73886L34-R34): Renamed the data provider method `createForPhpProvider` to `provideCreateForPhpCases` and added a type annotation specifying the return type as `iterable<array{GitStatus, ?string, ?string}>`. [[1]](diffhunk://#diff-2c037140500df0aea328f2e7461eb2a08a55ffdeec0fa33c0a8fe9e31fb73886L34-R34) [[2]](diffhunk://#diff-2c037140500df0aea328f2e7461eb2a08a55ffdeec0fa33c0a8fe9e31fb73886L59-R62)